### PR TITLE
Dereference null return value in gdfx.c

### DIFF
--- a/src/gdfx.c
+++ b/src/gdfx.c
@@ -265,6 +265,9 @@ gdImageSquareToCircle (gdImagePtr im, int radius)
 		return 0;
 	}
 	im2 = gdImageCreateTrueColor (radius * 2, radius * 2);
+	if (!im2) {
+		return 0;
+	}
 	/* Supersampling for a nicer result */
 	c = (im2->sx / 2) * SUPER;
 	for (y = 0; (y < im2->sy * SUPER); y++) {


### PR DESCRIPTION
Issue : gdImageSquareToCircle() may possibly return NULL pointer. 

im2 = gdImageCreateTrueColor (radius \* 2, radius \* 2);

im2 can hold NULL value when 0 returned. 

Should be null checked.
